### PR TITLE
Add responsive navigation menu

### DIFF
--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -1,0 +1,69 @@
+import Link from "next/link";
+import { useState } from "react";
+
+export default function Navbar() {
+  const [open, setOpen] = useState(false);
+  return (
+    <nav className="w-full bg-background border-b border-foreground/10">
+      <div className="mx-auto max-w-screen-xl px-4 sm:px-6 lg:px-8">
+        <div className="flex items-center justify-between h-16">
+          <Link href="/" className="text-lg font-semibold">
+            Bob Hotline
+          </Link>
+          <button
+            className="sm:hidden inline-flex items-center justify-center p-2 rounded-md hover:bg-foreground/5 focus:outline-none"
+            onClick={() => setOpen(!open)}
+            aria-label="Toggle navigation menu"
+          >
+            <svg
+              className="h-6 w-6"
+              stroke="currentColor"
+              fill="none"
+              viewBox="0 0 24 24"
+            >
+              {open ? (
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              ) : (
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M4 6h16M4 12h16M4 18h16"
+                />
+              )}
+            </svg>
+          </button>
+          <div className="hidden sm:flex space-x-8">
+            <Link href="/" className="hover:underline">
+              Home
+            </Link>
+            <Link href="#about" className="hover:underline">
+              About
+            </Link>
+            <Link href="#contact" className="hover:underline">
+              Contact
+            </Link>
+          </div>
+        </div>
+      </div>
+      {open && (
+        <div className="sm:hidden px-2 pb-4 pt-2 space-y-1">
+          <Link href="/" className="block px-3 py-2 rounded-md hover:bg-foreground/5">
+            Home
+          </Link>
+          <Link href="#about" className="block px-3 py-2 rounded-md hover:bg-foreground/5">
+            About
+          </Link>
+          <Link href="#contact" className="block px-3 py-2 rounded-md hover:bg-foreground/5">
+            Contact
+          </Link>
+        </div>
+      )}
+    </nav>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import Navbar from "./components/Navbar";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,6 +28,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <Navbar />
         {children}
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -99,5 +99,15 @@ export default function Home() {
         </a>
       </footer>
     </div>
+    <section id="about" className="max-w-screen-md mx-auto p-8">
+      <h2 className="text-xl font-semibold mb-2">About</h2>
+      <p className="text-sm text-foreground/80">
+        This is a sample project demonstrating a responsive navigation menu.
+      </p>
+    </section>
+    <section id="contact" className="max-w-screen-md mx-auto p-8">
+      <h2 className="text-xl font-semibold mb-2">Contact</h2>
+      <p className="text-sm text-foreground/80">Feel free to reach out!</p>
+    </section>
   );
 }


### PR DESCRIPTION
## Summary
- add a responsive navbar component with desktop and mobile menu
- include Navbar in layout
- add About and Contact sections for menu links

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846cdb6155c83229db66fdaff49804d